### PR TITLE
fix header path for xcode 13.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
     targets: [
         .target(
             name: "RecaptchaEnterpriseSwift",
-            dependencies: ["recaptcha-enterprise"]//,
+            dependencies: ["recaptcha-enterprise"]
         ),
         .target (
             name: "recaptcha-enterprise",
@@ -66,7 +66,8 @@ let package = Package(
                            .product(name: "GULNSData", package: "GoogleUtilities"),
                            .product(name: "FBLPromises", package: "Promises"),
                            .product(name: "Promises", package: "Promises"),
-            ]
+            ],
+            publicHeadersPath: "."
         ),
         .binaryTarget(
             name: "recaptcha",


### PR DESCRIPTION
Xcode 13.3 fails to import the package with:
public headers ("include") directory path for 'recaptcha-enterprise' is invalid or not contained in the target

This change adds a publicHeader path to the package and this fix is confirmed on 13.3.1.  

I couldn't find clear documentation on what change occurred in Xcode/SPM to require this.